### PR TITLE
add --sep option for column splitting

### DIFF
--- a/sos/python/sos-import-csv
+++ b/sos/python/sos-import-csv
@@ -175,6 +175,8 @@ if __name__ == "__main__":
                         help="Specifies how CSV columns are mapped to attributes")
     parser.add_argument("--csv",
                         help="The path to the CSV file to import")
+    parser.add_argument("--sep", default=",",
+                        help="The separator character in the CSV file")
     parser.add_argument("--status", action="store_true",
                         help="Show detail import status")
     args = parser.parse_args()
@@ -236,7 +238,7 @@ if __name__ == "__main__":
             continue
         if l.endswith("\n"):
             l = l[:-1]
-        cols = l.split(',')
+        cols = l.split(args.sep)
         obj = schema.alloc()
         if not obj:
             print("An object with schema {0} could not be allocated.".format(schema.name()))


### PR DESCRIPTION
to work with slurm data (|) and other non-ldms, allows the user to specify alternate separators.