### PR TITLE
Fix Cython Sos:get_CHAR_ARRAY()

### DIFF
--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -3468,7 +3468,7 @@ cdef object get_BYTE_ARRAY(sos_obj_t c_obj, sos_value_data_t c_data, sos_attr_t 
     return res
 
 cdef object get_CHAR_ARRAY(sos_obj_t c_obj, sos_value_data_t c_data, sos_attr_t c_attr):
-    return str(c_data.array.data.char_[:c_data.array.count])
+    return c_data.array.data.char_[:c_data.array.count].decode()
 
 cdef object get_INT64_ARRAY(sos_obj_t c_obj, sos_value_data_t c_data, sos_attr_t c_attr):
     res = np.ndarray([ c_data.array.count ], dtype=np.dtype('int64'), order="C")


### PR DESCRIPTION
`str(char[])` gets translated to `str(bytes)` and results in
"b'CONTENT'" (a `str` with leading "b" character and "'" single quotes
surrounding the content). The `bytes` to `str` conversion should be done
using `bytes.decode()`.

NOTE: `char[]` is wrapped as `bytes` by Cython.