### PR TITLE
Sos 4 py3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ fi
 AC_DEFINE_UNQUOTED([ODS_COMMIT_ID],["$COMMIT_ID"], [Git commit id])
 AC_SUBST([ODS_COMMIT_ID],["$COMMIT_ID"])
 
+
 dnl Checks for programs
 AC_PROG_CC
 
@@ -23,17 +24,18 @@ OPTION_DOC
 
 OPTION_DEFAULT_DISABLE([debug], [ENABLE_DEBUG])
 OPTION_DEFAULT_ENABLE([python], [ENABLE_PYTHON])
-
-if test -z "$ENABLE_PYTHON_TRUE"
-then
-  AM_PATH_PYTHON(,,[:])
-  NUMPY_INCLUDE_PATH=$($PYTHON -c "import numpy; print(numpy.get_include())")
-  which cython >/dev/null 2>&1 || AC_MSG_ERROR("cython not found")
-  test -n "$NUMPY_INCLUDE_PATH" || AC_MSG_ERROR("numpy not found.")
-  AX_PYTHON_DEVEL()
-  AC_MSG_RESULT([${NUMPY_INCLUDE_PATH}])
-  AC_SUBST([NUMPY_INCLUDE_PATH])
+if test -z "$ENABLE_PYTHON_TRUE"; then
+	dnl check for python interpreter
+	test -n "$PYTHON" || export PYTHON=/usr/bin/python3
+ 	AM_PATH_PYTHON(,,[:])
+ 	AX_PYTHON_DEVEL([>='3'])
+ 	NUMPY_INCLUDE_PATH=$($PYTHON -c "import numpy; print(numpy.get_include())")
+ 	which cython >/dev/null 2>&1 || AC_MSG_ERROR("cython not found")
+ 	test -n "$NUMPY_INCLUDE_PATH" || AC_MSG_ERROR("numpy not found.")
+ 	AC_MSG_RESULT([${NUMPY_INCLUDE_PATH}])
+ 	AC_SUBST([NUMPY_INCLUDE_PATH])
 fi
+AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != :])
 
 distdir=${PACKAGE_NAME}-${PACKAGE_VERSION}
 AC_SUBST(ac_configure_args)

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -4684,7 +4684,7 @@ cdef void uint8_array_nda_setter(np.ndarray nda, int idx, sos_value_t v):
         ndb[i] = v.data.array.data.byte_[i]
 
 cdef void int8_array_nda_setter(np.ndarray nda, int idx, sos_value_t v):
-    nda[idx] = v.data.array.data.char_[:v.data.array.count].decode()
+    nda[idx] = v.data.array.data.char_[:v.data.array.count]
 
 cdef void int16_array_nda_setter(np.ndarray nda, int idx, sos_value_t v):
     cdef int i
@@ -5147,7 +5147,7 @@ cdef class QueryInputer:
                 if atyp >= TYPE_IS_ARRAY:
                     if atyp == SOS_TYPE_STRING:
                         data = np.zeros([ self.row_limit ],
-                                        dtype=np.dtype('|S{0}'.format(max_string)))
+                                        dtype=np.dtype('U{0}'.format(max_string)))
                     else:
                         data = np.zeros([ self.row_limit, int(max_array) ],
                                         dtype=np.dtype(typ_str))
@@ -5282,7 +5282,7 @@ cdef class QueryInputer:
             if atyp >= TYPE_IS_ARRAY:
                 if atyp == SOS_TYPE_STRING:
                     data = np.zeros([ self.row_count ],
-                                    dtype=np.dtype('|S{0}'.format(max_string)))
+                                    dtype=np.dtype('U{0}'.format(max_string)))
                 else:
                     data = np.zeros([ self.row_count, max_array ],
                                     dtype=np.dtype(typ_str))
@@ -5374,7 +5374,7 @@ cdef class QueryInputer:
             if atyp >= TYPE_IS_ARRAY:
                 if atyp == SOS_TYPE_STRING:
                     data = np.zeros([ self.row_count ],
-                                    dtype=np.dtype('|S{0}'.format(max_string)))
+                                    dtype=np.dtype('U{0}'.format(max_string)))
                 else:
                     data = np.zeros([ self.row_count, max_array ],
                                     dtype=np.dtype(typ_str))

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -52,7 +52,7 @@ import struct
 import sys
 import copy
 import binascii
-from sosdb import DataSet
+from sosdb.DataSet import DataSet
 cimport numpy as np
 
 #


### PR DESCRIPTION
Bug fix for DataSet import
Return strings rather than byte strings for CHAR_ARRAY attributes
Update configure to use python3, defaults to /usr/bin/python3 if PYTHON env variable not set