### PR TITLE
New optional parameter for sos_cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Compile Dependencies
 --------------------
 
 * For SOS python interface:
-  * Cython
-  * Python >= 2.7
+  * Cython >= .29 (Cython 3.0)
+  * Python >= 3.6
 
 Installation
 ------------
@@ -39,6 +39,7 @@ Installation
 mkdir build
 cd build
 ../configure --prefix=/SOS/INSTALL/PATH [--disable-python] [--enable-debug]
+# add 'PYTHON=/PYTHON/EXECUTABLE/PATH' if PYTHON environment variable not set
 # add `--enable-debug` to turn on debugging logic inside the SOS libraries
 # add `--disable-python` to disable the Python commands and interface libraries
 make && make install

--- a/sos/python/DataSet.py
+++ b/sos/python/DataSet.py
@@ -356,7 +356,7 @@ class DataSet(object):
                     v = int(v)
                 elif typ == np.datetime64:
                     # convert to milliseconds from microseconds
-                    v = v.astype(np.int64) // int(1e6)
+                    v = v.astype(np.int64) // 1000
                 else:
                     raise ValueError("Unrecognized numpy type {0}".format(typ))
                 aRow.append(v)

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -3842,13 +3842,17 @@ cdef set_TIMESTAMP(sos_attr_t c_attr, sos_value_data_t c_data, val):
             secs = <int>val[0]
             usecs = <int>val[1]
         except:
-            raise ValueError("A timestamp is a tuple of ( int(secs), int(usecs) )")
+            raise ValueError("Error assigning {0} to timestamp."\
+                              "A timestamp must be a tuple of "\
+                              "( int(secs), int(usecs) )".format(val))
     elif typ == float or typ == np.float64 or typ == np.float32:
         try:
             secs = int(val)
-            usecs = int((val * 1.e6) - (secs * 1.e6))
+            usecs = int((val - float(secs)) * 1.e6)
         except:
-            raise ValueError("The time value is a floating point secs.usecs number")
+            raise ValueError("Error assigning {0} to timestamp. "\
+                             "The time value of a floating point "\
+                             "number must be non-negative".format(val))
     elif typ == np.datetime64:
         ts = val.astype('int')
         secs = ts / 1000000L
@@ -3861,7 +3865,7 @@ cdef set_TIMESTAMP(sos_attr_t c_attr, sos_value_data_t c_data, val):
         secs = val
         usecs = 0
     else:
-        raise ValueError("timestamp of type {0}, must be float, tuple or int".format(type(val)))
+        raise ValueError("Timestamp of type {0}, must be float, tuple or int".format(type(val)))
     c_data.prim.timestamp_.tv.tv_sec = secs
     c_data.prim.timestamp_.tv.tv_usec = usecs
 

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -1424,6 +1424,9 @@ cdef class AttrIter(SosObject):
             return True
         return False
 
+    def next(self):
+        return next(self)
+
     def __next__(self):
         """Move the iterator position to the next object in the index
         Returns:


### PR DESCRIPTION
-E flag will exclude attribute from output
To exclude multiple attributes, reuse flag, e.g:

`` sos_cmd -C <cont> -qS <schema> -X <index> -E <attr_1> -E <attr_2>``