### PR TITLE
Fix timestamp setter to use uint64_t instead of int

### DIFF
--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -3834,8 +3834,8 @@ cdef set_CHAR_ARRAY(sos_attr_t c_attr, sos_value_data_t c_data, val):
         c_data.array.data.char_[i] = <bytes>s[i]
 
 cdef set_TIMESTAMP(sos_attr_t c_attr, sos_value_data_t c_data, val):
-    cdef int secs
-    cdef int usecs
+    cdef uint64_t secs
+    cdef uint64_t usecs
     cdef typ = type(val)
     if typ == tuple:
         try:


### PR DESCRIPTION
Change cdef int to cdef uint64_t to fix integer overflow error
