### PR TITLE
Fix build issue from a clean tree

### DIFF
--- a/rpc/Makefile.am
+++ b/rpc/Makefile.am
@@ -12,7 +12,7 @@ xdr-files : FORCE
 	rm -f $(srcdir)/sosapi.h
 FORCE :
 
-sosapi.h : sosapi.x xdr-files
+$(BUILT_SOURCES) : sosapi.x xdr-files
 	rpcgen -N -M $(srcdir)/sosapi.x
 
 AM_CFLAGS = -Wno-unused-variable \


### PR DESCRIPTION
The built sources generated by rpcgen needs to be specified on the
left-hand side of the make rule so that `make` knows that they are the
target of the rpcgen recipe. Otherwise, when building from a clean
source tree `make` complains:

    make[2]: *** No rule to make target `sosapi_svc.c', needed by `all'.  Stop.