### PR TITLE
Fix sos_array_new reallocation bug

### DIFF
--- a/sos/src/sos_schema.c
+++ b/sos/src/sos_schema.c
@@ -1023,6 +1023,7 @@ retry:
 			goto err;
 		obj_ref.ref.obj = ods_obj_ref(obj->obj);
 		obj->obj_ref = obj_ref;
+		val->data = (sos_value_data_t)&obj->obj->as.bytes[attr->data->offset];
 		failed = 1;
 		goto retry;
 	}


### PR DESCRIPTION
If the requested array is too big, the object is realloacted. However,
the `val->data` still pointed to the old object. As a result, array info
initialization:
```c
1013                 val->data->array_info.offset = off;
1014                 val->data->array_info.size = size;
```
would modify the old object memory and leaving the array_info in the new
object uninitialized. The `sos_value_init()` then returned NULL due to
uninitialized (0-value) array_info offset and `sos_array_new()` returned
NULL with errno 0.

Updating `val->data` to the reallocated object resolved the issue.