### PR TITLE
sos_schema_from_template() to generate uuid if it is NULL

### DIFF
--- a/sos/src/sos_schema.c
+++ b/sos/src/sos_schema.c
@@ -286,7 +286,13 @@ sos_schema_t sos_schema_from_template(sos_schema_template_t t)
 	int i, rc;
 	sos_schema_t schema;
 	uuid_t uuid;
-	uuid_parse(t->uuid, uuid);
+	if (t->uuid) {
+		rc = uuid_parse(t->uuid, uuid);
+		if (rc)
+			return NULL;
+	} else {
+		uuid_generate(uuid);
+	}
 	schema = sos_schema_create(t->name, uuid);
 	if (!schema)
 		goto err;


### PR DESCRIPTION
If the template does not specify uuid, it will be generated with
`uuid_generate()` (the same as `sos_schema_new()`). Also add a
`uuid_parse()` result checking in the case that the uuid is specified.