### PR TITLE
Fix multiple rpcgen calls in the build process

### DIFF
--- a/rpc/Makefile.am
+++ b/rpc/Makefile.am
@@ -12,7 +12,9 @@ xdr-files : FORCE
 	rm -f $(srcdir)/sosapi.h
 FORCE :
 
-$(BUILT_SOURCES) : sosapi.x xdr-files
+$(BUILT_SOURCES) : sosapi.x
+
+sosapi.h : sosapi.x xdr-files
 	rpcgen -N -M $(srcdir)/sosapi.x
 
 AM_CFLAGS = -Wno-unused-variable \


### PR DESCRIPTION
Having multiple targets in the make rule will cause GNU make to call the
recipe multiple times. However, having just `sosapi.h` alone will have
the following error (in CentOS 7, clean tree):

	make[2]: *** No rule to make target `sosapi_svc.c', needed by `all'.  Stop.

This patch work around the issues of "No rule" and "multiple recipe
execution" by using multi-target rule with empty recipe and a
single-target rule (`sosapi.h`) with the actual recipe execution. This
patch has been tested on CentOS 7, with a clean source tree. It
successfully built and executed the rpcgen recipe only once.