### PR TITLE
Add container name mapping support

### DIFF
--- a/rpc/Makefile.am
+++ b/rpc/Makefile.am
@@ -1,5 +1,6 @@
 AUTOMAKE_OPTIONS=subdir-objects
 SUBDIRS = . # python
+EXTRA_DIST=
 lib_LTLIBRARIES =
 sbin_PROGRAMS =
 bin_PROGRAMS =
@@ -52,4 +53,7 @@ dsosql_LDADD = ../lib/json/libsos_json.la ../sos/src/libsos.la libdsos.la -lpthr
 bin_PROGRAMS += dsosql
 
 AM_YFLAGS = -d
+
+dist_man8_MANS= \
+dsosd.man
 

--- a/rpc/dsosd.man
+++ b/rpc/dsosd.man
@@ -1,0 +1,36 @@
+.\" Manpage for the D/SOS dsosd daemon
+.TH man 8 "14 Mar 2022" "v5" "dsosd man page"
+
+.SH NAME
+dsosd \- Start an instance of the D/SOS RPC service on a node
+
+.SH SYNOPSIS
+dsosd
+
+.SH DESCRIPTION
+The dsosd command starts the D/SOS RPC service on a node. The D/SOS
+RPC service registers the D/SOS program number with the with the RPC
+portmapper on the TCP and UDP transports. Only a single instance of
+the daemon should be run at a time.
+
+.SH ENVIRONMENT
+.SS
+The following environment variables may be used to affect the
+configuration of the dsosd daemon.
+.TP
+DSOSD_DIRECTORY The path to a JSON formatted file that maps container
+names to local filesystem paths.
+.TP
+DSOSD_SERVER_ID A logical name for this dsosd instance. If not
+specified, the hostname (as determined by gethostname) will be
+used. This name is used to determine which sections of the directory
+file apply to this dsosd instance.
+.TP
+DSOSD_LOG_LEVEL The log level at which log messages are written to
+standard out.
+
+
+.SH SEE ALSO
+dsosql(8), dsosd_directory(7)
+
+


### PR DESCRIPTION
Container names are now administratively
controlled with a JSON configuration files.
This splits the mapping between the container
name and the path.