### PR TITLE
Make RPC concurrent

### DIFF
--- a/libtirpc/src/clnt_fd_locks.h
+++ b/libtirpc/src/clnt_fd_locks.h
@@ -50,6 +50,7 @@ static unsigned int fd_locks_prealloc = 0;
 /* per-fd lock */
 struct fd_lock_t {
 	bool_t active;
+	mutex_t lock;
 	cond_t cv;
 };
 typedef struct fd_lock_t fd_lock_t;
@@ -132,6 +133,7 @@ fd_locks_t* fd_locks_init() {
 		for (i = 0; i < fd_locks_prealloc; i++) {
 			fd_locks->fd_lock_array[i].active = FALSE;
 			cond_init(&fd_locks->fd_lock_array[i].cv, 0, (void *) 0);
+			mutex_init(&item->fd_lock.lock, (void *) 0);
 		}
 	}
 #endif
@@ -181,6 +183,7 @@ fd_lock_t* fd_lock_create(int fd, fd_locks_t *fd_locks) {
 		item->refs = 1;
 		item->fd_lock.active = FALSE;
 		cond_init(&item->fd_lock.cv, 0, (void *) 0);
+		mutex_init(&item->fd_lock.lock, (void *) 0);
 		TAILQ_INSERT_HEAD(list, item, link);
 	} else {
 		item->refs++;

--- a/ods/src/ods_mmap.c
+++ b/ods/src/ods_mmap.c
@@ -315,11 +315,22 @@ static void __lock_init(ods_lock_t *lock)
 	pthread_mutex_init(&lock->mutex, &attr);
 }
 
+static struct timespec default_wait = {
+	.tv_sec = 1,
+	.tv_nsec = 0
+};
+
 static int __take_lock(ods_lock_t *lock, struct timespec *wait)
 {
+	int rc;
 	if (!wait)
-		return pthread_mutex_lock(&lock->mutex);
-	return pthread_mutex_timedlock(&lock->mutex, wait);
+		wait = &default_wait;
+	do {
+		rc = pthread_mutex_timedlock(&lock->mutex, wait);
+		if (wait != &default_wait)
+			return rc;
+	} while (rc != 0);
+	return rc;
 }
 
 static void __release_lock(ods_lock_t *lock)

--- a/sos/src/sos_cmd.c
+++ b/sos/src/sos_cmd.c
@@ -644,9 +644,9 @@ void json_row(FILE *outp, sos_schema_t schema, sos_obj_t obj)
 				break;
 			case SOS_TYPE_OBJ_ARRAY:
 				fprintf(outp, "\"%s\" : [", col->name);
-				o = strtok_r(s, ',', &ptr);
+				o = strtok_r(s, ",", &ptr);
 				fprintf(outp, "\"%s\"", o);
-				for (; o; o = strtok_r(NULL, ',', &ptr)) {
+				for (; o; o = strtok_r(NULL, ",", &ptr)) {
 					fprintf(outp, ",\"%s\"", o);
 				}
 				fprintf(outp, "]");


### PR DESCRIPTION
* The libtirpc library had a global lock that effectively serialized client side RPC requests. This allows client RPC to be submitted concurrently.

* The ods lock implementation used pthread_mutex_lock without a timeout. On Power platforms this would cause locks in shared memory to sometimes hang when the process was exiting. This change works around that behavior.

* A previous change incorrectly specified 2nd strtok parameter as a character instead of a string. This would crash if ever executed.