### PR TITLE
Add partition UUID query capability

### DIFF
--- a/ods/include/ods/ods.h
+++ b/ods/include/ods/ods.h
@@ -542,10 +542,18 @@ void ods_obj_iter_pos_init(ods_obj_iter_pos_t pos);
  */
 int ods_obj_iter(ods_t ods, ods_obj_iter_pos_t pos, ods_obj_iter_fn_t iter_fn, void *arg);
 
+/**
+ * \brief Returns the number of objects in the container
+ *
+ * \param ods The ODS container handle
+ */
 ods_atomic_t ods_obj_count(ods_t ods);
 
-/*
- * Take a reference on an object
+/**
+ * \brief Take a reference on an object
+ *
+ * \param obj The object handle
+ * \returns Pointer to the \c obj parameter
  */
 ods_obj_t ods_obj_get(ods_obj_t obj);
 

--- a/ods/src/ods_mmap.c
+++ b/ods/src/ods_mmap.c
@@ -1,4 +1,4 @@
-/*
+/* -*- c-basic-offset : 8 -*-
  * Copyright (c) 2021 Open Grid Computing, Inc. All rights reserved.
  * Copyright (c) 2013 Sandia Corporation. All rights reserved.
  *

--- a/ods/src/ods_priv.h
+++ b/ods/src/ods_priv.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c-basic-offset : 8 -*-
  * Copyright (c) 2020 Open Grid Computing, Inc. All rights reserved.
  * Copyright (c) 2013 Sandia Corporation. All rights reserved.
  *

--- a/sos/include/sos/sos.h
+++ b/sos/include/sos/sos.h
@@ -508,6 +508,23 @@ typedef struct sos_part_obj_iter_pos_s {
 void sos_part_obj_iter_pos_init(sos_part_obj_iter_pos_t pos);
 int sos_part_obj_iter(sos_part_t part, sos_part_obj_iter_pos_t pos,
 		      sos_part_obj_iter_fn_t fn, void *arg);
+typedef struct sos_part_uuid_entry_s {
+	uuid_t uuid;		/*! The uuid_t */
+	long count;		/*! Number of objects with this UUID */
+} *sos_part_uuid_entry_t;
+
+/**
+ * \brief Query the schema UUID present in the partition
+ *
+ * Return an array of the schema UUID present in the partition
+ * and the number of objects using each UUID.
+ *
+ * \param part The partition handle
+ * \param count Pointer to receive the number of entries returned
+ * \returns Array of uuid entries or NULL if no objects are present.
+ */
+sos_part_uuid_entry_t sos_part_query_schema_uuid(sos_part_t part, size_t *count);
+
 /** @} */
 /** @} */
 

--- a/sos/python/Sos.pxd
+++ b/sos/python/Sos.pxd
@@ -533,6 +533,11 @@ cdef extern from "sos/sos.h":
         pass
     ctypedef sos_part_s *sos_part_t
 
+    cdef struct sos_part_uuid_entry_s:
+        uuid_t uuid
+        long count
+    ctypedef sos_part_uuid_entry_s *sos_part_uuid_entry_t
+
     sos_part_t sos_part_open(const char *path, int o_perm, int o_mode, const char *desc)
     int sos_part_chown(sos_part_t part, uid_t uid, gid_t gid)
     int sos_part_chmod(sos_part_t part, int perm)
@@ -567,6 +572,7 @@ cdef extern from "sos/sos.h":
     int sos_part_obj_iter(sos_part_t part, sos_part_obj_iter_pos_t pos,
                           sos_part_obj_iter_fn_t fn, void *arg)
     size_t sos_part_remap_schema_uuid(sos_part_t part, const char *dst_path, const char *src_path)
+    sos_part_uuid_entry_t sos_part_query_schema_uuid(sos_part_t part, size_t *count)
 
     cdef enum sos_byte_order_e:
         SOS_OBJ_BE,

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -1383,6 +1383,22 @@ cdef class Partition(SosObject):
                                                        src_path.encode())
         return (count, errno)
 
+    def query_schema_uuid(self):
+        """Query the schema present in a partition
+
+        Obtain a list of all unique schema being used in a partition
+        and return this as a list of (uuid_t, use_count) tuples.
+        """
+        cdef sos_part_uuid_entry_t c_uuid_array
+        cdef size_t c_count
+        cdef int i
+        uuid = []
+        c_uuid_array = sos_part_query_schema_uuid(self.c_part, &c_count)
+        for i in range(0, c_count):
+            uuid.append( (c_uuid_array[i].uuid, c_uuid_array[i].count) )
+        free(c_uuid_array)
+        return uuid
+
     def state_set(self, new_state):
         """Set the partition state"""
         cdef int rc

--- a/sos/python/sos-part
+++ b/sos/python/sos-part
@@ -51,6 +51,7 @@ import errno
 import argparse
 import pwd
 import grp
+import uuid
 from sosdb import Sos
 
 def fmt_size(size):
@@ -222,6 +223,9 @@ if __name__ == "__main__":
                          help="Replace the schema UUID in a partition. "
                          "Used when importing a partition that was populated "
                          "using a different schema dictionary.")
+    actions.add_argument("--show-schema", action="store_true",
+                         help="Show the set of schema UUID that are "
+                         "used by objects in the partition.")
     args = parser.parse_args()
 
     #
@@ -434,5 +438,22 @@ if __name__ == "__main__":
                       "valid JSON.")
             elif err != 0:
                 print(f"Error {err} was returned remapping the partition's UUID")
+        sys.exit(1)
+    #
+    # Show a partition's schema UUID
+    #
+    if args.show_schema:
+        part = Sos.Partition()
+        try:
+            part.open(args.path)
+        except:
+            print(f"The partition '{args.path}' could not be opened")
+            sys.exit(1)
+        uuid_list = part.query_schema_uuid()
+        print("Schema UUID                          Use Count")
+        print("------------------------------------ ------------")
+        for entry in uuid_list:
+            u = uuid.UUID(bytes=entry[0][0:16])
+            print(str(u), entry[1])
         sys.exit(1)
     sys.exit(0)

--- a/sos/python/sos-schema
+++ b/sos/python/sos-schema
@@ -50,6 +50,7 @@ import argparse
 from sosdb import Sos
 import json
 import os
+import uuid
 
 def add_schema(cont, path):
     try:
@@ -61,10 +62,12 @@ def add_schema(cont, path):
     except Exception as ex:
         print(str(ex))
 
-def query_schema(cont, schema_name, verbose=False):
+def query_schema(cont, schema_name=None, uuid_str=None, verbose=False):
     count = 0
     for s in cont.schema_iter():
         if schema_name is not None and s.name() != schema_name:
+            continue
+        if uuid_str is not None and s.uuid() != uuid.UUID(uuid_str):
             continue
         count += 1
         print(f"{s.name()} '{s.uuid()}'")
@@ -106,6 +109,8 @@ if __name__ == "__main__":
                         help="The path to the container.")
     parser.add_argument("-s", "--schema", metavar="NAME", dest="schema", default=None,
                          help="The schema name")
+    parser.add_argument("-u", "--uuid", metavar="NAME", dest="uuid", default=None,
+                         help="The schema UUID string")
     parser.add_argument("-v", "--verbose", action="store_true",
                          help="Print the schema and all of its attributes")
     actions = parser.add_mutually_exclusive_group(required=True)
@@ -151,7 +156,12 @@ if __name__ == "__main__":
             print(str(ex))
 
     if args.query:
-        query_schema(cont, args.schema, verbose=args.verbose)
+        if args.schema:
+            query_schema(cont, schema_name=args.schema, verbose=args.verbose)
+        elif args.uuid:
+            query_schema(cont, uuid_str=args.uuid, verbose=args.verbose)
+        else:
+            query_schema(cont, verbose=args.verbose)
 
     if args.add:
         add_schema(cont, args.add)

--- a/sos/src/sos_priv.h
+++ b/sos/src/sos_priv.h
@@ -471,6 +471,7 @@ int __sos_config_init(sos_t sos);
 sos_schema_t __sos_schema_init(sos_t sos, ods_obj_t schema_obj);
 ods_obj_t __sos_obj_new(ods_t ods, size_t size, pthread_mutex_t *lock);
 void __sos_schema_free(sos_schema_t schema);
+void __sos_schema_print(ods_obj_t schema_obj, FILE *fp);
 void __sos_part_primary_set(sos_t sos, ods_obj_t part_obj);
 sos_part_t __sos_primary_obj_part(sos_t sos);
 int __sos_part_create(const char *part_path, const char *part_desc,

--- a/sos/src/sos_schema.c
+++ b/sos/src/sos_schema.c
@@ -1968,6 +1968,7 @@ void __sos_schema_print(ods_obj_t schema_obj, FILE *fp)
 	}
 	fprintf(fp, "\n    ]\n");
 	fprintf(fp, "  }");
+	fflush(fp);
  err_0:
 	free(attr_names);
 	return;
@@ -2049,18 +2050,6 @@ int sos_schema_export(const char *path_arg, FILE *fp)
 		ods_obj_put(udata);
 		goto err_1;
 	}
-
-#if 0
-	if (!is_supported_version(SOS_SCHEMA_UDATA(udata)->version, SOS_LATEST_VERSION)) {
-		errno = EPROTO;
-		sos_error("Schema ODS in %s is an unsupported version expected %llX, got %llx\n",
-			  path_arg,
-			  SOS_LATEST_VERSION,
-			  SOS_SCHEMA_UDATA(udata)->version);
-		ods_obj_put(udata);
-		goto err_1;
-	}
-#endif
 	ods_obj_put(udata);
 
 	/* Open the index on the schema objects */


### PR DESCRIPTION
This set of changes allow an administrator to query the
set of schema UUID that are referenced by objects in a
partition. This service is needed when attaching partions
to new containers to know which schema need to be present
in the container to succesfully decode the objects.