### PR TITLE
Containerized arm64 cython --gdb work around

### DIFF
--- a/sos/python/Makefile.am
+++ b/sos/python/Makefile.am
@@ -19,9 +19,11 @@ pkgpython_PYTHON = __init__.py DataSet.py
 
 dist_bin_SCRIPTS = sos-db sos-part sos-schema sos-import-csv sos-monitor
 
+CYTHON_GDB = $(shell [ "$(uname -p)" = "x86_64" ] && echo --gdb || echo "" )
+
 Sos.c: Sos.pyx Sos.pxd
 	echo PYTHON_LDFLAGS are "$(PYTHON_LDFLAGS)"
-	cython -3 --gdb --directive language_level=3 $< -o $@
+	cython -3 $(CYTHON_GDB) --directive language_level=3 $< -o $@
 
 clean-local:
 	rm -f Sos.c


### PR DESCRIPTION
cython with `--gdb` option resulted in "segmentation fault" when `make`
built sos python module on arm64 (aarch64) containers. This issue does
not appear on x86_64 containers. This patch adds a work around to
only enable `cython --gdb` option for x86_64 architecture.