### PR TITLE
Add index verification services

### DIFF
--- a/ods/src/bxt.c
+++ b/ods/src/bxt.c
@@ -52,9 +52,12 @@
 #include <ods/ods.h>
 #include <ods/ods_idx.h>
 #include "bxt.h"
+#include "ods_log.h"
 
 /* #define ODS_DEBUG */
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+
+#define TPRINTF(_fp_, _fmt_, ...) fprintf(_fp_, "%s: " _fmt_ , ods_path(t->ods), ## __VA_ARGS__)
 
 static int split_midpoint(int order);
 static struct bxt_obj_el *alloc_el(bxt_t t);
@@ -219,12 +222,12 @@ static int verify_record(bxt_t t, ods_obj_t rec, FILE *fp)
 {
 	int rc = 0;
 	if (REC(rec)->next_ref == rec->ref) {
-		fprintf(fp, "The record's next pointer %p creates a cycle.\n",
+		TPRINTF(fp, "The record's next pointer %p creates a cycle.\n",
 			(void *)rec->ref);
 		rc = 1;
 	}
 	if (REC(rec)->prev_ref == rec->ref) {
-		fprintf(fp, "The record's prev pointer %p creates a cycle.\n",
+		TPRINTF(fp, "The record's prev pointer %p creates a cycle.\n",
 			(void *)rec->ref);
 		rc = 1;
 	}
@@ -239,34 +242,34 @@ static int verify_leaf(bxt_t t, ods_obj_t l, int is_root, FILE *fp)
 	int midpoint = split_midpoint(t->udata->order);
 
 	if (!is_root && NODE(l)->count < midpoint) {
-		fprintf(fp, "The leaf %p has only %d < %d entries\n",
+		TPRINTF(fp, "The leaf %p has only %d < %d entries\n",
 			(void *)l->ref, NODE(l)->count, midpoint);
 		rc = 1;
 	}
 	if (NODE(l)->count > t->udata->order) {
-		fprintf(fp, "The leaf %p has too many %d > %d entries\n",
+		TPRINTF(fp, "The leaf %p has too many %d > %d entries\n",
 			(void *)l->ref, NODE(l)->count, t->udata->order);
 		rc = 1;
 	}
 	for (i = 0; i < NODE(l)->count; i++) {
 		for (j = 0; j < NODE(l)->count; j++) {
 			if (L_ENT(l,i).head_ref == 0) {
-				fprintf(fp, "Leaf %p's entry %d head reference should not be NULL\n", (void *)l->ref, i);
+				TPRINTF(fp, "Leaf %p's entry %d head reference should not be NULL\n", (void *)l->ref, i);
 				rc = 1;
 				continue;
 			}
 			if (L_ENT(l,i).tail_ref == 0) {
-				fprintf(fp, "Leaf %p's entry %d tail reference should not be NULL\n", (void *)l->ref, i);
+				TPRINTF(fp, "Leaf %p's entry %d tail reference should not be NULL\n", (void *)l->ref, i);
 				rc = 1;
 				continue;
 			}
 			if (i != j && L_ENT(l,i).head_ref == L_ENT(l,j).head_ref) {
-				fprintf(fp, "Leaf %p's entry %d head_ref %p should not equal entry %d\n",
+				TPRINTF(fp, "Leaf %p's entry %d head_ref %p should not equal entry %d\n",
 					(void *)l->ref, i, (void *)L_ENT(l, i).head_ref, j);
 				rc = 1;
 			}
 			if (i != j && L_ENT(l,i).tail_ref == L_ENT(l,j).tail_ref) {
-				fprintf(fp, "Leaf %p's entry %d tail_ref %p should not equal entry %d\n",
+				TPRINTF(fp, "Leaf %p's entry %d tail_ref %p should not equal entry %d\n",
 					(void *)l->ref, i, (void *)L_ENT(l, i).tail_ref, j);
 				rc = 1;
 			}
@@ -274,7 +277,7 @@ static int verify_leaf(bxt_t t, ods_obj_t l, int is_root, FILE *fp)
 		rec_ref = L_ENT(l, i).head_ref;
 		rec = ods_ref_as_obj(t->ods, rec_ref);
 		if (!rec) {
-			fprintf(fp, "Leaf %p entry %d record reference %p is invalid.\n",
+			TPRINTF(fp, "Leaf %p entry %d record reference %p is invalid.\n",
 				(void *)l->ref, i, (void *)rec_ref);
 			rc = 1;
 			continue;
@@ -299,7 +302,7 @@ static int verify_node(bxt_t t, ods_obj_t n, FILE *fp)
 	/* Verify the node's cardinality */
 	if (!((NODE(n)->count >= midpoint) &&
 	       (NODE(n)->count <= t->udata->order))) {
-		fprintf(fp, "Node %p's cardinality is incorrect %d <= %d <= %d\n",
+		TPRINTF(fp, "Node %p's cardinality is incorrect midpoint %d <= count %d <= order %d\n",
 			(void *)n->ref,
 			midpoint, NODE(n)->count, t->udata->order);
 		rc = 1;
@@ -312,13 +315,13 @@ static int verify_node(bxt_t t, ods_obj_t n, FILE *fp)
 
 		c_ref = N_ENT(n, i).node_ref;
 		if (!c_ref) {
-			fprintf(fp, "Node %p's entry %d should not be NULL\n", (void *)n->ref, i);
+			TPRINTF(fp, "Node %p's entry %d should not be NULL\n", (void *)n->ref, i);
 			rc |= 1;
 			continue;
 		}
 		c = ods_ref_as_obj(t->ods, c_ref);
 		if (!c) {
-			fprintf(fp, "Node %p's entry %d reference %p is invalid.\n",
+			TPRINTF(fp, "Node %p's entry %d reference %p is invalid.\n",
 				(void *)n->ref, i, (void *)c_ref);
 			rc |= 1;
 			continue;
@@ -340,14 +343,14 @@ static int verify_idx(ods_idx_t idx, FILE* fp)
 
 	root = ods_ref_as_obj(t->ods, t->udata->root_ref);
 	if (!root) {
-		fprintf(fp, "The root reference %p is invalid.\n",
+		TPRINTF(fp, "The root reference %p is invalid.\n",
 			(void *)t->udata->root_ref);
 		return 1;
 	}
 
 	/* Parent should be nil */
 	if (NODE(root)->parent != 0)
-		fprintf(fp, "The root %p's parent should be NULL, not %p\n",
+		TPRINTF(fp, "The root %p's parent should be NULL, not %p\n",
 			(void *)root->ref, (void *)NODE(root)->parent);
 
 	/* Check if root is leaf */
@@ -359,14 +362,14 @@ static int verify_idx(ods_idx_t idx, FILE* fp)
 		ods_ref_t ref = N_ENT(root,i).node_ref;
 		ods_obj_t node;
 		if (!ref) {
-			fprintf(fp, "Root node %p's entry %d should not be NULL\n",
+			TPRINTF(fp, "Root node %p's entry %d should not be NULL\n",
 				(void *)root->ref, i);
 			rc |= 1;
 			continue;
 		}
 		node = ods_ref_as_obj(t->ods, ref);
 		if (!node) {
-			fprintf(fp, "Root node %p's entry %d reference %p is invalid.\n",
+			TPRINTF(fp, "Root node %p's entry %d reference %p is invalid.\n",
 				(void *)root->ref, i, (void *)ref);
 			rc |= 1;
 			continue;
@@ -497,15 +500,19 @@ ods_obj_t leaf_find(bxt_t t, ods_key_t key)
 	int depth = 2;
 
 	if (!t->udata->root_ref)
-		return 0;
+		return NULL;
 
 	n = ods_ref_as_obj(t->ods, t->udata->root_ref);
+	if (!n)
+		goto corrupted;
 	while (!NODE(n)->is_leaf) {
 		int64_t rc;
 		depth += 1;
 		for (i = 1; i < NODE(n)->count; i++) {
 			ods_obj_t entry_key =
 				ods_ref_as_obj(t->ods, N_ENT(n,i).key_ref);
+			if (!entry_key)
+				goto corrupted;
 			rc = t->comparator(key, entry_key);
 			ods_obj_put(entry_key);
 			if (rc >= 0)
@@ -516,9 +523,16 @@ ods_obj_t leaf_find(bxt_t t, ods_key_t key)
 		ref = N_ENT(n,i-1).node_ref;
 		ods_obj_put(n);
 		n = ods_ref_as_obj(t->ods, ref);
+		if (!n)
+			goto corrupted;
 	}
 	t->udata->depth = depth;
 	return n;
+corrupted:
+	/* Corrupted index */
+	ods_lerror("The index '%s' is corrupted.\n", ods_path(t->ods));
+	errno = EINVAL;
+	return NULL;
 }
 
 static ods_obj_t rec_find(bxt_t t, ods_key_t key, int first)

--- a/sos/include/sos/sos.h
+++ b/sos/include/sos/sos.h
@@ -725,6 +725,7 @@ int64_t sos_index_key_cmp(sos_index_t index, sos_key_t a, sos_key_t b);
 void sos_index_print(sos_index_t index, FILE *fp);
 const char *sos_index_name(sos_index_t index);
 int sos_index_stat(sos_index_t index, sos_index_stat_t sb);
+int sos_index_verify(sos_index_t index, FILE *fp);
 void sos_container_index_list(sos_t sos, FILE *fp);
 typedef struct sos_container_index_iter_s *sos_container_index_iter_t;
 sos_container_index_iter_t sos_container_index_iter_new(sos_t sos);

--- a/sos/python/Makefile.am
+++ b/sos/python/Makefile.am
@@ -17,7 +17,7 @@ pkgpyexecdir = $(pkgpythondir)
 
 pkgpython_PYTHON = __init__.py DataSet.py
 
-dist_bin_SCRIPTS = sos-db sos-part sos-schema sos-import-csv sos-monitor
+dist_bin_SCRIPTS = sos-db sos-part sos-schema sos-import-csv sos-monitor sos-index
 
 Sos.c: Sos.pyx Sos.pxd
 	echo PYTHON_LDFLAGS are "$(PYTHON_LDFLAGS)"

--- a/sos/python/Sos.pxd
+++ b/sos/python/Sos.pxd
@@ -683,6 +683,7 @@ cdef extern from "sos/sos.h":
     const char *sos_index_key_to_str(sos_index_t index, sos_key_t key)
     int sos_index_key_cmp(sos_index_t index, sos_key_t a, sos_key_t b)
     void sos_index_print(sos_index_t index, FILE *fp)
+    int sos_index_verify(sos_index_t index, FILE *fp)
     const char *sos_index_name(sos_index_t index)
     int sos_index_stat(sos_index_t index, sos_index_stat_t sb)
     void sos_container_index_list(sos_t sos, FILE *fp)

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -4455,6 +4455,13 @@ cdef class Index(object):
         """Print the contents of the index to stdout"""
         sos_index_print(self.c_index, NULL);
 
+    def verify(self):
+        """Verify the contents of the index
+        Errors are printed to stdout
+        """
+        cdef int rc = sos_index_verify(self.c_index, NULL);
+        return rc
+
 ################################
 # Object getter functions
 ################################

--- a/sos/python/sos-index
+++ b/sos/python/sos-index
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 Open Grid Computing, Inc. All rights reserved.
+# Copyright (c) 2022 NTESS Corporation. All rights reserved.
+# Under the terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+# license for use of this work by or on behalf of the U.S. Government.
+# Export of this program may require a license from the United States
+# Government.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the BSD-type
+# license below:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#      Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#      Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#
+#      Neither the name of NTESS Corporation, Open Grid Computing nor
+#      the names of any contributors may be used to endorse or promote
+#      products derived from this software without specific prior
+#      written permission.
+#
+#      Modified source versions must be plainly marked as such, and
+#      must not be misrepresented as being the original software.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from builtins import str
+import datetime as dt
+import sys
+import argparse
+from sosdb import Sos
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Query metric data in a container")
+    parser.add_argument("-p", "--path", metavar="PATH", required=True, dest="path",
+                        help="The path to the container.")
+    parser.add_argument("-q", "--query", action="store_true",
+                         help="Print all of the container's indices.")
+    parser.add_argument("-V", "--verify", action="store_true",
+                         help="Verify the consistency of one or all indices.")
+    parser.add_argument("-n", "--index", metavar="NAME", dest="index_name", default=None,
+                         help="Verify only the specified index name.")
+    args = parser.parse_args()
+
+    try:
+        cont = Sos.Container()
+        cont.open(args.path)
+    except:
+        print(f"The container {args.path} could not be opened.")
+        sys.exit(1)
+
+    if args.query:
+        idx_iter = cont.index_iter()
+        for idx in idx_iter:
+            print(f"{idx.name()}")
+
+    if not args.verify:
+        sys.exit(0)
+
+    idx_iter = cont.index_iter()
+    for idx in idx_iter:
+        if args.index_name:
+                if args.index_name != idx.name():
+                        continue
+        print(f"Verifying index '{idx.name()}' ...", end='')
+        sys.stdout.flush()
+        rc = idx.verify()
+        if rc == 0:
+                print(f" OK")
+        else:
+                print(f" CORRUPTED")
+

--- a/sos/src/sos.c
+++ b/sos/src/sos.c
@@ -598,20 +598,6 @@ void sos_index_info(sos_index_t index, FILE *fp)
 	ods_info(ods_idx_ods(iref->idx), fp, ODS_INFO_ALL);
 }
 
-/**
- * @brief Verify the internal consistency of an index
- *
- * @param index The index handle
- * @param fp A FILE pointer into which error information is reported
- * @returns 0 The index is consistent
- * @returns Consult \c fp for error message(s)
- */
-int sos_index_verify(sos_index_t index, FILE *fp)
-{
-	ods_idx_ref_t iref = LIST_FIRST(&index->active_idx_list);
-	return ods_idx_verify(iref->idx, fp);
-}
-
 int print_schema(struct ods_rbn *n, void *fp_, int level)
 {
 	FILE *fp = fp_;

--- a/sos/src/sos_index.c
+++ b/sos/src/sos_index.c
@@ -853,6 +853,24 @@ void sos_index_print(sos_index_t index, FILE *fp)
 		ods_idx_print(iref->idx, (fp ? fp : stdout));
 }
 
+/**
+ * @brief Verify the internal consistency of an index
+ *
+ * @param index The index handle
+ * @param fp A FILE pointer into which error information is reported
+ * @returns 0 The index is consistent
+ * @returns Consult \c fp for error message(s)
+ */
+int sos_index_verify(sos_index_t index, FILE *fp)
+{
+	int rc = 0;
+	ods_idx_ref_t iref;
+	LIST_FOREACH(iref, &index->active_idx_list, entry) {
+		if (ods_idx_verify(iref->idx, (fp ? fp : stdout)))
+			rc = -1;
+	}
+	return rc;
+}
 struct sos_container_index_iter_s {
 	sos_t sos;
 	ods_iter_t iter;

--- a/sos/src/sos_iter.c
+++ b/sos/src/sos_iter.c
@@ -84,7 +84,7 @@ static sos_filter_cond_t __sos_find_filter_condition(sos_filter_t filt,
 static sos_obj_t next_match(sos_filter_t filt);
 static sos_obj_t prev_match(sos_filter_t filt);
 
-#if 0
+#ifdef SOS_DEBUG
 static int __iter_rbn_printer(struct ods_rbn *rbn, void *-arg, int level)
 {
 	ods_key_t key = rbn->key;
@@ -380,7 +380,7 @@ static int __sos_iter_obj_ref_new(sos_iter_t sos_iter, ods_iter_t ods_iter,
 	ods_rbt_ins(&sos_iter->rbt, &new_ref->rbn);
 	if (rbn)
 		*rbn = &new_ref->rbn;
-#if 0
+#ifdef SOS_DEBUG
 	ods_rbt_verify(&sos_iter->rbt);
 	printf("----------\n");
 	ods_rbt_print(&sos_iter->rbt, __iter_rbn_printer, NULL);
@@ -402,7 +402,7 @@ static int __sos_iter_pos_iter(sos_iter_t sos_iter, ods_iter_t ods_iter)
 	sos_iter->pos = iter_obj_ref;
 	ods_rbn_init(&iter_obj_ref->rbn, iter_obj_ref->key);
 	ods_rbt_ins(&sos_iter->rbt, &iter_obj_ref->rbn);
-#if 0
+#ifdef SOS_DEBUG
 	ods_rbt_verify(&sos_iter->rbt);
 	printf("----------\n");
 	ods_rbt_print(&sos_iter->rbt, __iter_rbn_printer, NULL);
@@ -477,7 +477,7 @@ int sos_iter_next(sos_iter_t i)
 	sos_key_put(i->pos->key);
 	free(i->pos);
 	i->pos = NULL;
-#if 0
+#ifdef SOS_DEBUG
 	printf("----------\n");
 	ods_rbt_print(&i->rbt, __iter_rbn_printer, NULL);
 #endif
@@ -560,7 +560,7 @@ int sos_iter_prev(sos_iter_t i)
 	sos_key_put(i->pos->key);
 	free(i->pos);
 	i->pos = NULL;
-#if 0
+#ifdef SOS_DEBUG
 	printf("----------\n");
 	ods_rbt_print(&i->rbt, __iter_rbn_printer, NULL);
 #endif


### PR DESCRIPTION
This change adds capabilities to the sos-index, sos-part and sos-schema commands to allow for the verification and fixing of indices.