### PR TITLE
Add the missing 'libtirpc/libdsosrpc.pc.in' file

### DIFF
--- a/libtirpc/libdsosrpc.pc.in
+++ b/libtirpc/libdsosrpc.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libdsosrpc
+Description: Transport Independent RPC Library
+Requires:
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -ldsosrpc
+Libs.private: -lpthread
+Cflags: -I${includedir}/dsosrpc


### PR DESCRIPTION
The added libdsosrpc.pc.in is the libtirpc.pc.in file with 'tirpc' being replaced by 'dsosrpc'.