### PR TITLE
Fix dsos_query_errmsg() declaration in Sos.pyd

### DIFF
--- a/sos/python/Sos.pxd
+++ b/sos/python/Sos.pxd
@@ -878,7 +878,7 @@ cdef extern from "dsos.h":
     dsos_query_t dsos_query_create(dsos_container_t cont)
     void dsos_query_destroy(dsos_query_t query)
     int dsos_query_select(dsos_query_t query, const char *clause)
-    char *dsos_query_errmsg(dsos_query_t query)
+    const char *dsos_query_errmsg(dsos_query_t query)
     sos_obj_t dsos_query_next(dsos_query_t query)
     sos_schema_t dsos_query_schema(dsos_query_t query)
     void dsos_name_array_free(dsos_name_array_t name)


### PR DESCRIPTION
The C code dsos_query_errmsg() API returns a const char*, but in .pyd, char* is returned. This causes a build fail using cython version 0.29.28.