### PR TITLE
Fix ods index data comparator

### DIFF
--- a/ods/src/ods_idx_priv.h
+++ b/ods/src/ods_idx_priv.h
@@ -158,7 +158,6 @@ static inline int ods_idx_data_null(ods_idx_data_t *data)
 }
 static inline int ods_idx_data_equal(ods_idx_data_t *a, ods_idx_data_t *b)
 {
-	return ((a->uint64_[0] == b->uint64_[0])
-		&& (a->uint64_[1] == b->uint64_[1]));
+	return 0 == memcmp(a, b, sizeof(*a));
 }
 #endif


### PR DESCRIPTION
Commit d5454a3f5eb9492b95e2d5e7386e9e04dcf02458 resized the `ods_idx_data_s` structure from 16 bytes to 32 bytes, but did not modify the `ods_idx_data_equal()` function. As a result, `bxt` removed an incorrect record as the comparator only compared half of the index data.