### PR TITLE
Fix sosapi_client iterator missing objects

### DIFF
--- a/rpc/sosapi_client.c
+++ b/rpc/sosapi_client.c
@@ -2431,7 +2431,6 @@ static int iter_obj_add(dsos_iter_t iter, int client_id)
 		pthread_mutex_unlock(&iter->obj_tree_lock);
 
 		iter->counts[client_id] += 1;
-		count += 1;
 	}
 	return 0;
 }


### PR DESCRIPTION
The `count` loop variable had redundant increment inside the loop, making dsos iterator cached every other object returned from the dsos server.