### PR TITLE
Malloc size

### DIFF
--- a/rpc/dsos.h
+++ b/rpc/dsos.h
@@ -87,6 +87,7 @@ extern int dsos_obj_create(dsos_container_t cont, dsos_part_t part,
 	dsos_schema_t schema, sos_obj_t obj);
 extern int dsos_obj_update(dsos_container_t cont, sos_obj_t obj);
 extern sos_obj_t dsos_obj_new(dsos_schema_t schema);
+extern sos_obj_t dsos_obj_new_size(dsos_schema_t schema, size_t reserve);
 extern dsos_iter_t dsos_iter_create(dsos_container_t cont, dsos_schema_t schema, const char *attr_name);
 extern void dsos_iter_delete(dsos_iter_t iter);
 extern sos_obj_t dsos_iter_obj(dsos_iter_t iter);

--- a/rpc/sosapi_client.c
+++ b/rpc/sosapi_client.c
@@ -2035,6 +2035,11 @@ sos_obj_t dsos_obj_new(dsos_schema_t schema)
 	return sos_obj_malloc(schema->schema);
 }
 
+extern sos_obj_t dsos_obj_new_size(dsos_schema_t schema, size_t reserve)
+{
+	return sos_obj_malloc_size(schema->schema, reserve);
+}
+
 /**
  * @brief Create a DSOS object
  *

--- a/sos/include/sos/sos.h
+++ b/sos/include/sos/sos.h
@@ -618,6 +618,7 @@ sos_obj_t sos_obj_new(sos_schema_t schema);
 sos_obj_t sos_obj_new_size(sos_schema_t schema, size_t reserve);
 sos_obj_t sos_obj_new_from_data(sos_schema_t schema, uint8_t *data, size_t data_size);
 sos_obj_t sos_obj_malloc(sos_schema_t schema);
+sos_obj_t sos_obj_malloc_size(sos_schema_t schema, size_t reserve);
 int sos_obj_commit(sos_obj_t obj);
 int sos_obj_commit_part(sos_obj_t obj, sos_part_t part);
 sos_schema_t sos_obj_schema(sos_obj_t obj);

--- a/sos/python/Sos.pxd
+++ b/sos/python/Sos.pxd
@@ -589,6 +589,7 @@ cdef extern from "sos/sos.h":
     sos_obj_t sos_obj_new(sos_schema_t schema)
     sos_obj_t sos_obj_new_with_data(sos_schema_t schema, uint8_t *data, size_t data_size)
     sos_obj_t sos_obj_malloc(sos_schema_t schema)
+    sos_obj_t sos_obj_malloc_size(sos_schema_t schema, size_t reserve)
     int sos_obj_commit(sos_obj_t obj)
     sos_schema_t sos_obj_schema(sos_obj_t obj)
 

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -1930,9 +1930,13 @@ cdef class Schema(SosObject):
         """Returns the name of the schema"""
         return sos_schema_name(self.c_schema).decode('utf-8')
 
-    def malloc(self):
+    def malloc(self, reserve = None):
         """Allocate a new memory object of this type"""
-        cdef sos_obj_t c_obj = sos_obj_malloc(self.c_schema)
+        cdef sos_obj_t c_obj
+        if reserve is not None:
+            c_obj = sos_obj_malloc_size(self.c_schema, reserve)
+        else:
+            c_obj = sos_obj_malloc(self.c_schema)
         if c_obj == NULL:
             self.abort()
         o = Object()

--- a/sos/src/sos.c
+++ b/sos/src/sos.c
@@ -1489,6 +1489,23 @@ err_0:
  */
 sos_obj_t sos_obj_malloc(sos_schema_t schema)
 {
+	return sos_obj_malloc_size(schema, DEFAULT_ARRAY_RESERVE);
+}
+
+/**
+ * \brief Allocate a SOS object in memory, with array reserve
+ *
+ * This call allocates a memory based object with array reserve that is not
+ * stored in the container.
+ *
+ * \param schema        The schema handle
+ * \param reserve       The size (in bytes) of the additional memory reserved
+ *                      for arrays in the object.
+ * \returns Pointer to the new object
+ * \returns NULL if there is an error
+ */
+sos_obj_t sos_obj_malloc_size(sos_schema_t schema, size_t reserve)
+{
 	ods_obj_t ods_obj;
 	sos_obj_ref_t obj_ref = NULL_REF;
 	if (!schema)
@@ -1496,7 +1513,7 @@ sos_obj_t sos_obj_malloc(sos_schema_t schema)
 		errno = EINVAL;
 		return NULL;
 	}
-	size_t array_data_sz = schema->data->array_cnt * DEFAULT_ARRAY_RESERVE;
+	size_t array_data_sz = schema->data->array_cnt * reserve;
 	ods_obj = ods_obj_malloc(schema->data->obj_sz + array_data_sz);
 	if (!ods_obj)
 		goto err_0;


### PR DESCRIPTION
dsos application uses `sos_obj_malloc()`, modify, and create (or update) routine to create a dsos object. `sos_obj_malloc_size()` is missing for an object creation with a non-default reserve memory size (e.g. a message in baler). This pull request contains the following patches:

- Add `sos_obj_malloc_size()` that allows C application to allocate in-memory sos object with a specific memory reserve.
- Add optional `reserve` parameter to Python `Dsos.Schema.malloc()` to allow Python application to allocate in-memory sos object with a memory reserve.
- Add `dsos_obj_new_size()` for completeness (since we have `dsos_obj_new()`).
