### PR TITLE
Fix dsos_transaction_begin() to honor `timeout`

### DIFF
--- a/sos/python/Sos.pxd
+++ b/sos/python/Sos.pxd
@@ -783,7 +783,7 @@ cdef extern from "sos/sos.h":
     int sos_filter_flags_set(sos_filter_t filt, sos_iter_flags_t flags)
     sos_iter_flags_t sos_filter_flags_get(sos_filter_t filt)
 
-cdef extern from "dsos.h":
+cdef extern from "dsos.h" nogil:
 
     cdef enum dsos_error:
         DSOS_ERR_OK,

--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -688,15 +688,18 @@ cdef class DsosContainer:
         if wait_secs:
             tv.tv_secs = int(wait_secs)
             tv.tv_nsecs = 0
-            rc = dsos_transaction_begin(self.c_cont, &tv)
+            with nogil:
+                rc = dsos_transaction_begin(self.c_cont, &tv)
         else:
-            rc = dsos_transaction_begin(self.c_cont, NULL)
+            with nogil:
+                rc = dsos_transaction_begin(self.c_cont, NULL)
         if rc != 0:
             raise ValueError(f"Error {rc} attempting to start a transaction")
 
     def transaction_end(self):
         cdef int rc
-        rc = dsos_transaction_end(self.c_cont)
+        with nogil:
+            rc = dsos_transaction_end(self.c_cont)
         if rc != 0:
             raise ValueError(f"Error {rc} attempting to start a transaction")
 


### PR DESCRIPTION
`dsos_transaction_begin()` should be a 'blocking' call if the `timeout` argument is NULL, or a timed-wait call if `timeout` parameter is given.

REMARK: The 'nogil' patch in the Cython code is to release the Python's Global Interpreter Lock (GIL) before we call (with a chance of blocking) the dsos transaction functions. Otherwise, other Python's threads could not proceed since the blocking-caller was also holding the GIL.