### PR TITLE
Fix Python Sos.DsosSchema intializer

### DIFF
--- a/sos/python/Sos.pyx
+++ b/sos/python/Sos.pyx
@@ -374,7 +374,6 @@ cdef class DsosSchema(Schema):
         Schema.__init__(self)
         self.dcont = cont
         self.c_dschema = <dsos_schema_t>NULL
-        self.dcont = None
 
     def attr_iter(self):
         return iter(self)


### PR DESCRIPTION
DsosSchema initializer set its `dcont` using the supplied `cont` from the `__init__()` function argument, but then reset `dcont` to `None`. This seems to be a typological error. With `dcont` being `None`, the subsequent attributes obtain from DsosSchema will not be able to perform `find` because it does not have a reference to the DsosContainer.