### PR TITLE
build fixes from OpenSUSE Leap 16.0

### DIFF
--- a/libtirpc/src/Makefile.am
+++ b/libtirpc/src/Makefile.am
@@ -5,7 +5,7 @@
 ## program built.  We also don't bother trying to assemble code, or
 ## anything like that.
 
-CFLAGS := $(filter-out -Werror, ${CFLAGS})
+CFLAGS = $(filter-out -Werror, @CFLAGS@)
 noinst_HEADERS = rpc_com.h debug.h clnt_fd_locks.h nis.h libtirpc.map
 
 AM_CPPFLAGS = -I$(top_srcdir)/libtirpc/tirpc -include config.h -DPORTMAP -DINET6 \

--- a/libtirpc/src/Makefile.am
+++ b/libtirpc/src/Makefile.am
@@ -25,7 +25,7 @@ libdsosrpc_la_SOURCES = auth_none.c auth_unix.c authunix_prot.c \
         rpc_callmsg.c rpc_generic.c rpc_soc.c rpcb_clnt.c rpcb_prot.c \
         rpcb_st_xdr.c svc.c svc_auth.c svc_dg.c svc_auth_unix.c svc_auth_none.c \
         svc_generic.c svc_raw.c svc_run.c svc_simple.c svc_vc.c getpeereid.c \
-        auth_time.c debug.c 
+        auth_time.c debug.c
 
 if AUTHDES
 libdsosrpc_la_SOURCES += auth_des.c  authdes_prot.c  des_crypt.c  des_impl.c  des_soft.c  svc_auth_des.c

--- a/libtirpc/src/Makefile.am
+++ b/libtirpc/src/Makefile.am
@@ -9,7 +9,8 @@ CFLAGS = $(filter-out -Werror, @CFLAGS@)
 noinst_HEADERS = rpc_com.h debug.h clnt_fd_locks.h nis.h libtirpc.map
 
 AM_CPPFLAGS = -I$(top_srcdir)/libtirpc/tirpc -include config.h -DPORTMAP -DINET6 \
-		-D_GNU_SOURCE -Wall -pipe
+		-D_GNU_SOURCE -Wall -pipe \
+		-std=gnu11
 
 lib_LTLIBRARIES = libdsosrpc.la
 

--- a/rpc/Makefile.am
+++ b/rpc/Makefile.am
@@ -21,6 +21,7 @@ sosapi.h : sosapi.x xdr-files
 	mv $(srcdir)/xx.c $(srcdir)/sosapi_svc.c
 
 AM_CFLAGS = -Wno-unused-variable \
+	-std=gnu11 \
 	-I$(top_srcdir)/libtirpc/tirpc \
 	-I$(srcdir)/../include \
 	-I$(top_srcdir)/ods/include \

--- a/rpc/sosapi_client.c
+++ b/rpc/sosapi_client.c
@@ -2868,7 +2868,7 @@ int dsos_query_select(dsos_query_t query, const char *clause)
 	if (res.any_err == 0)
 		query->state = DSOS_QUERY_SELECT;
 	else
-		snprintf(g_last_errmsg, sizeof(g_last_errmsg), query->err_msg);
+		snprintf(g_last_errmsg, sizeof(g_last_errmsg), "%s", query->err_msg);
 	return res.any_err;
 }
 

--- a/sos/src/sos.c
+++ b/sos/src/sos.c
@@ -1377,7 +1377,7 @@ char *sos_container_stats(sos_t sos, uint64_t mask)
 		pthread_mutex_lock(&cont_list_lock);
 		LIST_FOREACH(sos, &cont_list, entry) {
 			char *json = __sos_container_stats(sos, mask);
-			printf(json);
+			printf("%s", json);
 		}
 		pthread_mutex_unlock(&cont_list_lock);
 	}


### PR DESCRIPTION
This PR addresses a few issues found when I tried to build this on openSUSE Leap 16.0

- `./configure CFLAGS` being ignored in `libtirpc`
  - Issue caused by using `${CFLAGS}` instead of `@CFLAGS@` on righ-hand value in `Makefile.am`.
- The new (which is default) gnu23 GCC standard broke `libtirpc` and `rpc` shipped with `sos`. For example, `int fn();` prototype in older standard (e.g. gnu17) meant a function with _any_ number of arguments, but gnu23 took it as having _exactly_ zero arguments. Setting `-std=gnu11` in `libtirpc` and `rpc` build resolved the incompatibility issue.
  - Maybe we want to update `libtirpc` and `rpc` to make it conform with gnu23 standard. I'm not quite sure if the update would break older build.
- `printf` format nits.
- Trailing white space nit.